### PR TITLE
Update Mirage GraphQL and search query resolver

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.1.4",
-    "@miragejs/graphql": "^0.1.3",
+    "@miragejs/graphql": "^0.1.5",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",

--- a/src/mocking/server.ts
+++ b/src/mocking/server.ts
@@ -13,10 +13,11 @@ createServer({
     const graphqlHandler = createGraphQLHandler(graphQLSchema, this.schema, {
       resolvers: {
         Query: {
-          search() {
-            const dogs = mockDogs.map((d) => ({ ...d, __typename: "Dog" }));
-            const cats = mockCats.map((d) => ({ ...d, __typename: "Cat" }));
-            const items = [...dogs, ...cats];
+          search(_obj: any, _args: any, { mirageSchema: { cats, dogs } }: any) {
+            const items = [
+              ...dogs.all().models,
+              ...cats.all().models
+            ];
 
             let rankCount = 0;
             const resolverReturn = items.reduce((acc, item) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1315,10 +1315,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@miragejs/graphql@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@miragejs/graphql/-/graphql-0.1.3.tgz#346d871f4515da2826525fb7180f27dce503b1ed"
-  integrity sha512-mGJrV6LSM+91hVsMpV/yMJKR5u2mWBXxg5x/3Cy1zP4MjK+WsfhC0Ywn9beUxe6Cb9/4Ypj4CMav7wdF0pJD7w==
+"@miragejs/graphql@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@miragejs/graphql/-/graphql-0.1.5.tgz#6382d6807c003c345ed3b56127af94dbe8e376e1"
+  integrity sha512-kWSZOfFONa2linyR4qUnDncO0Usqz2RRZ3h/z90NRUXpYxVYAth6EJnLE50FuB5e1e9XhxGzy4ElEx2yqluCtQ==
   dependencies:
     graphql "^15.0.0"
     miragejs "^0.1.0"


### PR DESCRIPTION
This PR updates to the latest version of Mirage GraphQL and updates the `search` query resolver to pull the dogs and cats from Mirage's database to associate with the search results.